### PR TITLE
4.4-overfitting-and-underfitting (5th notebook)

### DIFF
--- a/keras/4.4-overfitting-and-underfitting.ipynb
+++ b/keras/4.4-overfitting-and-underfitting.ipynb
@@ -35,6 +35,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that you have to allocate 32g memory to `SPARK_DRIVER_MEMORY` if you are about to finish the contents in this notebook. Perhaps there is no such memory left on your machine, see memory saving approach at [Chapter 3.5](https://github.com/intel-analytics/zoo-tutorials/blob/master/keras/3.7-predicting-house-prices.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Overfitting and underfitting\n",
     "\n",
     "\n",


### PR DESCRIPTION
5th notebook of zoo tutorial keras api, contains bigger, smaller, L2, dropout comparisons

This notebook requires very large spark driver memory now and this notebook gets its result by two separate runs. This issue is not totally fixed thus there is no zoo code pull request corresponds.